### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ Ce projet utilise des données expérimentales d'essais œdométriques sur des a
 
 ```bash
 pip install -r requirements.txt
-python src/model_training.py
+python src
+```


### PR DESCRIPTION
## Summary
- close the fenced code block in README
- fix the command to run the training script

## Testing
- `python src` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_683f945beed8832fb2bc979c8da57814